### PR TITLE
230630yh-calendarsevent

### DIFF
--- a/src/components/FriendCalendarModal.jsx
+++ b/src/components/FriendCalendarModal.jsx
@@ -33,6 +33,7 @@ export default function FriendCalendarModal({friendName}) {
           <div className={friendcalendar["calendarheader"]}>
             <div
               onClick={() => {
+                nowdayB.setDate(1)
                 setNowdayB(new Date(nowdayB.setMonth(nowdayB.getMonth() - 1)));
               }}
             >
@@ -43,6 +44,7 @@ export default function FriendCalendarModal({friendName}) {
 
             <div
               onClick={() => {
+                nowdayB.setDate(1)
                 setNowdayB(new Date(nowdayB.setMonth(nowdayB.getMonth() + 1)));
               }}
             >

--- a/src/pages/GroupDetail.jsx
+++ b/src/pages/GroupDetail.jsx
@@ -218,6 +218,10 @@ export default function GroupDetail() {
         // console.log(grouptitle)
     }, [group])
 
+    const dateone=()=>{
+        nowday.setDate(1);
+        nextday.setDate(1);
+    }
     return (
         <div className={mainStyle.wrap}>
             <div className={homeStyle['home-wrap']}>
@@ -232,11 +236,13 @@ export default function GroupDetail() {
                         <div className={homeStyle['left-top-right']}>
                             <div className={homeStyle['left-top-prev']}
                                 onClick={() => {
+                                    dateone()
                                     setNowday(new Date(nowday.setMonth(nowday.getMonth() - 2)));
                                     setNextday(new Date(nextday.setMonth(nextday.getMonth() - 2)));
                                 }}><RxDoubleArrowLeft /></div>
                             <div className={homeStyle['left-top-next']}
                                 onClick={() => {
+                                    dateone()
                                     setNowday(new Date(nowday.setMonth(nowday.getMonth() + 2)));
                                     setNextday(new Date(nextday.setMonth(nextday.getMonth() + 2)));
                                 }}><RxDoubleArrowRight /></div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -46,7 +46,11 @@ export default function Home() {
     const [nextday, setNextday] = useState(
         new Date(now.setMonth(now.getMonth() + 1))
     );
-
+    
+    const dateone=()=>{
+        nowday.setDate(1);
+        nextday.setDate(1);
+    }
     const allTimeline = [
         {
             id: 1,
@@ -228,11 +232,13 @@ export default function Home() {
                         <div className={homeStyle['left-top-right']}>
                             <div className={homeStyle['left-top-prev']}
                                 onClick={() => {
+                                    dateone()
                                     setNowday(new Date(nowday.setMonth(nowday.getMonth() - 2)));
                                     setNextday(new Date(nextday.setMonth(nextday.getMonth() - 2)));
                                 }}><RxDoubleArrowLeft /></div>
                             <div className={homeStyle['left-top-next']}
                                 onClick={() => {
+                                    dateone()
                                     setNowday(new Date(nowday.setMonth(nowday.getMonth() + 2)));
                                     setNextday(new Date(nextday.setMonth(nextday.getMonth() + 2)));
                                 }}><RxDoubleArrowRight /></div>

--- a/src/pages/Mypage.jsx
+++ b/src/pages/Mypage.jsx
@@ -317,6 +317,7 @@ export default function MyPage() {
                                             <div className={`${mypage[`calendar-title-wrap`]}`}>
                                                 <div
                                                     onClick={() => {
+                                                        nowdayA.setDate(1)
                                                         setNowdayA(new Date(nowdayA.setMonth(nowdayA.getMonth() - 1)));
                                                     }}
                                                 >
@@ -325,6 +326,7 @@ export default function MyPage() {
                                                 <h4>캘린더 A</h4>
                                                 <div
                                                     onClick={() => {
+                                                        nowdayA.setDate(1)
                                                         setNowdayA(new Date(nowdayA.setMonth(nowdayA.getMonth() + 1)));
                                                     }}
                                                 >
@@ -340,6 +342,7 @@ export default function MyPage() {
                                             <div className={`${mypage[`calendar-title-wrap`]} ${mypage[`calendar-b-box`]}`}>
                                                 <div
                                                     onClick={() => {
+                                                        nowdayB.setDate(1)
                                                         setNowdayB(new Date(nowdayB.setMonth(nowdayB.getMonth() - 1)));
                                                     }}
                                                 >
@@ -348,6 +351,7 @@ export default function MyPage() {
                                                 <h4>캘린더 B</h4>
                                                 <div
                                                     onClick={() => {
+                                                        nowdayB.setDate(1)
                                                         setNowdayB(new Date(nowdayB.setMonth(nowdayB.getMonth() + 1)));
                                                     }}
                                                 >


### PR DESCRIPTION
특정일 이 없는 달의 경우 넘어갈 때 해당 월을 넘긴 다음달 넘기는 현상 수정 : 달력 넘기는 버튼 클릭 시 1일로 고정
예) 1월 30일 에서 다음달 누르면 2월 30일 이지만 없는 날이라서 3월로 넘어감
비슷한 8월 31일 에서 다음달 누르면 9월 31일 이지만 없는 날이라서 10월로 넘어감