### PR TITLE
Sl B캘린더 가짜 날짜 추가 데이터 홈캘린더에도 적용

### DIFF
--- a/src/components/AddGroupMember.jsx
+++ b/src/components/AddGroupMember.jsx
@@ -4,12 +4,7 @@ import mainStyle from "../css/sass.module.scss";
 import list from "../css/list.module.scss";
 import mdl from '../css/modal.module.scss';
 import { useDispatch, useSelector } from "react-redux";
-import AddFriend from "../components/AddFriend";
-import AddGroupSample from "../components/AddGroupSample";
-import { deletefriendList, getfriendList, noSessionfriendList } from "../slice/friendSlice";
 import { LuX } from "react-icons/lu";
-import { updateBtn } from "../slice/listArrayslice";
-import friendlist from '../css/friendlist.module.scss'
 import { db } from "../database/firebase";
 import { collection, doc, getDocs, or, query, updateDoc, where } from "firebase/firestore";
 import { getgroupList } from "../slice/groupSlice";
@@ -18,7 +13,7 @@ import FriendCheckbox from "./FriendCheckbox";
 export default function AddGroupMember() {
     const navigate = useNavigate("");
 
-    const {gName} = useParams();
+    const { gName } = useParams();
 
     // 리덕스 저장 정보
     const user = useSelector((state) => state.user.user);
@@ -33,23 +28,23 @@ export default function AddGroupMember() {
     const groupData = JSON.parse(sessionStorage.getItem('group'));
     const listArrayData = JSON.parse(sessionStorage.getItem('listArray'));
 
-    useEffect(()=>{
-        if(!groupData) {
+    useEffect(() => {
+        if (!groupData) {
             navigate('/')
         }
-    },[])
+    }, [])
 
     const selectG = groupData && groupData.filter((g) => g.gName === gName)[0];
     // console.log(selectG);
-    const mem = selectG && selectG.member.map(it=>it.fid);
+    const mem = selectG && selectG.member.map(it => it.fid);
     // console.log(mem);
 
     // 그룹 만들 선택 친구 배열 (값 props로 넘겨주기)
     const [selectFriends, setSelectFriends] = useState([]);
-    
+
     // 모달 on off
     const [openModal, setOpenModal] = useState(false);
-    
+
     // 이름순 정렬
     const [nameBtn, setNameBtn] = useState(true);
     // const [mem, setMem] = useState(selectG ? selectG.member.map(it=>it.fid) : []);
@@ -60,9 +55,9 @@ export default function AddGroupMember() {
     // console.log(mem, fid)
     // console.log(friendData.filter((f) => !mem.includes(f.fid) ));
 
-    useEffect(()=>{
+    useEffect(() => {
         setMemArray(friendData && friendData.filter((f) => !mem.includes(f.fid)));
-    },[group])
+    }, [group])
 
     // 이름순 정렬 관리 함수
     const handleNameSort = () => {
@@ -193,24 +188,24 @@ export default function AddGroupMember() {
                             </div>
                             {/**친구별 */}
                             <div className={list["container2"]}>
-                                {memArray &&
+                                {memArray[0] ?
                                     (
                                         memArray
-                                        .filter((friend) => (displayType === "" || (displayType === "A" && friend.showCalA) || (displayType === "B" && !friend.showCalA)))
-                                        .map((friend) => (
-                                            <div
-                                                className={list["list-box-groupmem"]}
-                                                key={friend.fid}
-                                                style={{
-                                                    // ShowCalA 를 이용하여 A캘린더에 등록된사람은 #5567b1
-                                                    // B캘린더에 등록된 사람은 #9ddce8 으로 뜨게 하기
-                                                    backgroundColor: friend.showCalA ? "#5567b1" : "#9ddce8",
-                                                    color: "white",
-//                                                    fontStyle: friend.fState ? "normal" : "italic"
-                                                }}
-                                            >
+                                            .filter((friend) => (displayType === "" || (displayType === "A" && friend.showCalA) || (displayType === "B" && !friend.showCalA)))
+                                            .map((friend) => (
+                                                <div
+                                                    className={list["list-box-groupmem"]}
+                                                    key={friend.fid}
+                                                    style={{
+                                                        // ShowCalA 를 이용하여 A캘린더에 등록된사람은 #5567b1
+                                                        // B캘린더에 등록된 사람은 #9ddce8 으로 뜨게 하기
+                                                        backgroundColor: friend.showCalA ? "#5567b1" : "#9ddce8",
+                                                        color: "white",
+                                                        //                                                    fontStyle: friend.fState ? "normal" : "italic"
+                                                    }}
+                                                >
                                                     <div className={list['list-container']}>
-                                                {/* <div className={friendlist["test2-groupmem"]}>
+                                                        {/* <div className={friendlist["test2-groupmem"]}>
                                                     <input
                                                         type="checkbox"
                                                         className={`${friendlist["checkbox2"]}`}
@@ -222,10 +217,18 @@ export default function AddGroupMember() {
                                                         {friend.fName}
                                                     </div>
                                                 </div> */}
-                                                <FriendCheckbox f={friend} checkFriends={checkFriends} selectFriends={selectFriends}/>
-                                </div>
-                                            </div>)
-                                        ))}
+                                                        <FriendCheckbox f={friend} checkFriends={checkFriends} selectFriends={selectFriends} />
+                                                    </div>
+                                                </div>)
+                                            )) :
+                                    <div
+                                        className={`${list["list-box-groupmem"]}`}
+                                    >
+                                        <div className={list['list-container']}>
+                                            모든 친구를 초대했습니다.
+                                        </div>
+                                    </div>
+                                }
                             </div>
                             {/** 친구 하단 버튼 */}
                             <div className={list["ttt-groupmem"]}>

--- a/src/components/FriendCheckbox.jsx
+++ b/src/components/FriendCheckbox.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import friendlist from "../css/friendlist.module.scss";
 import list from '../css/list.module.scss'
 import mainStyle from '../css/sass.module.scss'

--- a/src/components/FriendListModal.jsx
+++ b/src/components/FriendListModal.jsx
@@ -11,7 +11,7 @@ import friendlist from '../css/friendlist.module.scss'
 import AddFriend from "../components/AddFriend";
 import AddGroupSample from "../components/AddGroupSample";
 import FriendProfileModal from '../components/FriendProfileModal';
-import { deletefriendList, getfriendList, noSessionfriendList } from "../slice/friendSlice";
+import { getfriendList } from "../slice/friendSlice";
 import { updateBtn } from "../slice/listArrayslice";
 
 import { LuX } from "react-icons/lu";

--- a/src/components/GroupListModal.jsx
+++ b/src/components/GroupListModal.jsx
@@ -6,9 +6,8 @@ import list from "../css/list.module.scss";
 import { useDispatch, useSelector } from "react-redux";
 
 import { deletegroupList, getgroupList } from '../slice/groupSlice';
-import { BiHeart, BiSolidHeart } from 'react-icons/bi'
 import { LuX } from "react-icons/lu";
-import { adduserMark, deleteuserMark, updateMark } from "../slice/markSlice";
+import { updateMark } from "../slice/markSlice";
 import { FaHeart } from 'react-icons/fa'
 import { FiHeart } from 'react-icons/fi'
 import { updateBtn } from "../slice/listArrayslice";

--- a/src/js/Bcal.js
+++ b/src/js/Bcal.js
@@ -1,11 +1,16 @@
 import CalenderModal from "../components/CalenderModal";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useState, useEffect } from "react";
 import ddd from "../css/ddd.module.scss";
+import { bDateUpdate } from "../slice/calendarSlice";
 
 export default function Customdatecelwrapper(props) {
 
   const groupData = JSON.parse(sessionStorage.getItem("group"));
+  const bDateData = JSON.parse(sessionStorage.getItem("bDate"));
+  const bDate = useSelector(state=>state.bDate);
+  const dispatch = useDispatch();
+  // 세션 스토로지 값에는 해외 기준 날짜로 표기됨 (작동에는 문제 없음)
 
   let dayconcat = [];
   let finalget = [];
@@ -16,52 +21,14 @@ export default function Customdatecelwrapper(props) {
   const ffnalget = finalget.map((date) => new Date(date.time));
   // console.log(ffnalget)
   const daysA = dayconcat.concat(ffnalget);
-  // console.log(daysA);
-
-  // const daysA = [
-  //   new Date("2023-07-25"),
-  //   new Date("2023-06-25"),
-  //   new Date("2023-06-17"),
-  //   new Date("2023-06-01"),
-  //   new Date("2023-07-01"),
-  //   new Date("2023-05-21"),
-  //   new Date("2023-07-05"),
-  //   new Date("2023-06-08"),
-  //   new Date("2023-08-05"),
-  // ];
-
-  let [daysB, setDaysB] = useState([
-    new Date("2023-06-20"),
-    new Date("2023-05-28"),
-    new Date("2023-06-04"),
-    new Date("2023-06-16"),
-    new Date("2023-05-29"),
-    new Date("2023-06-05"),
-    new Date("2023-06-14"),
-    new Date("2023-05-30"),
-    new Date("2023-06-07"),
-    new Date("2023-06-13"),
-    new Date("2023-06-22"),
-    new Date("2023-05-31"),
-    new Date("2023-06-06"),
-    new Date("2023-06-20"),
-    new Date("2023-06-02"),
-    new Date("2023-06-12"),
-    new Date("2023-06-10"),
-    new Date("2023-06-24"),
-    new Date("2023-06-28"),
-    new Date("2023-06-21"),
-    new Date("2023-06-27"),
-    new Date("2023-06-11"),
-    new Date("2023-06-26"),
-    new Date("2023-06-29"),
-    new Date("2023-06-19"),
-    new Date("2023-06-23"),
-  ]);
+  
+  const getbday = bDateData && bDateData.map((data) => new Date(data));
+  let [daysB, setDaysB] = useState(getbday);
+  // console.log(daysB)
 
   const [isSpecialDay, setIsSpecialDay] = useState(false);
 
-  const days = daysA.concat(daysB);
+  // const days = daysA.concat(daysB);
 
   const dayArrayA = [];
 
@@ -84,13 +51,23 @@ export default function Customdatecelwrapper(props) {
     sumA = dayArrayA.reduce((previous, current) => previous || current);
   }
   const dayArrayB = [];
+  // for (let i = 0; i < daysB.length; i++) {
+  //   let bool =
+  //     daysB[i].getDate() === props.value.getDate() &&
+  //     daysB[i].getMonth() === props.value.getMonth() &&
+  //     daysB[i].getFullYear() === props.value.getFullYear();
+  //   dayArrayB.push(bool);
+  // }
+  // console.log(dayArrayB)
+
   for (let i = 0; i < daysB.length; i++) {
     let bool =
-      daysB[i].getDate() === props.value.getDate() &&
-      daysB[i].getMonth() === props.value.getMonth() &&
-      daysB[i].getFullYear() === props.value.getFullYear();
+    (daysB[i].getDate() === props.value.getDate() &&
+    daysB[i].getMonth() === props.value.getMonth() &&
+    daysB[i].getFullYear() === props.value.getFullYear()) 
     dayArrayB.push(bool);
   }
+  // console.log(dayArrayB)
   const sumB = dayArrayB.reduce((previous, current) => previous || current);
   const clickCal = () => {
     if (
@@ -104,6 +81,7 @@ export default function Customdatecelwrapper(props) {
         let addarray = [];
         addarray = daysB.concat(props.value);
         setDaysB(addarray);
+        dispatch(bDateUpdate(addarray));
       } else {
         let deletearray = [];
         deletearray = daysB.filter(
@@ -113,6 +91,7 @@ export default function Customdatecelwrapper(props) {
             e.getDate() !== props.value.getDate()
         );
         setDaysB(deletearray);
+        dispatch(bDateUpdate(deletearray));
       }
     } else {
       alert("취소되었습니다.");

--- a/src/js/Customdatecelwrapper.js
+++ b/src/js/Customdatecelwrapper.js
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import CalenderModal from "../components/CalenderModal";
 import SeeMoinModal from "../components/SeeMoinModal";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useState } from "react";
 import { sessionarray } from "../pages/Calender";
 import NoneScheduleModal from "../components/NoneScheduleModal";
@@ -13,6 +13,8 @@ export default function Customdatecelwrapper(props) {
   // console.log(`커스텀값 : ${nowdate}`)
   const seeAcal = useSelector((state) => state.user.seeAcal);
   // console.log(seeAcal)
+  const bDateData = JSON.parse(sessionStorage.getItem("bDate"));
+  const dispatch = useDispatch();
   const daysA = [
     // new Date("2023-07-25"),
     // new Date("2023-06-25"),
@@ -25,34 +27,8 @@ export default function Customdatecelwrapper(props) {
     // new Date("2023-08-05"),
   ];
   //B캘린더는 A캘린더보다 색칠되는 값이 많아야 하므로 더미데이터를 추가해놓음
-  const daysB = daysA.concat([
-    new Date("2023-06-20"),
-    new Date("2023-05-28"),
-    new Date("2023-06-04"),
-    new Date("2023-06-16"),
-    new Date("2023-05-29"),
-    new Date("2023-06-05"),
-    new Date("2023-06-14"),
-    new Date("2023-05-30"),
-    new Date("2023-06-07"),
-    new Date("2023-06-13"),
-    new Date("2023-06-22"),
-    new Date("2023-05-31"),
-    new Date("2023-06-06"),
-    new Date("2023-06-20"),
-    new Date("2023-06-02"),
-    new Date("2023-06-12"),
-    new Date("2023-06-10"),
-    new Date("2023-06-24"),
-    new Date("2023-06-28"),
-    new Date("2023-06-21"),
-    new Date("2023-06-27"),
-    new Date("2023-06-11"),
-    new Date("2023-06-26"),
-    new Date("2023-06-29"),
-    new Date("2023-06-19"),
-    new Date("2023-06-23"),
-  ]);
+  const getbday = bDateData && bDateData.map((data) => new Date(data));
+  const daysB = daysA.concat(getbday);
   //Home에서 dispatch로 seeAcal(bool값)을 변경해주고 true이면 daysA 배열로, false면 daysB 배열로 변경되도록 설정함
   const dayconcat = seeAcal ? daysA : daysB;
   //달력 중 해달 날짜값이 있다면 true, 없다면 false로 만들 배열

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -13,6 +13,7 @@ import { getappointmentList } from '../slice/appointmentSlice';
 import MainBg from '../components/MainBg';
 import { updateMark } from '../slice/markSlice';
 import { updateBtn } from '../slice/listArrayslice';
+import { bDateUpdate } from '../slice/calendarSlice';
 
 export default function Login() {
 
@@ -131,6 +132,37 @@ export default function Login() {
                     friendDup: true,
                     friendNup: true,
                 }));
+
+                // 유저 B 캘린더 더미 값
+                dispatch(bDateUpdate([
+                    new Date("2023-06-20"),
+                    new Date("2023-05-28"),
+                    new Date("2023-06-04"),
+                    new Date("2023-06-16"),
+                    new Date("2023-05-29"),
+                    new Date("2023-06-05"),
+                    new Date("2023-06-14"),
+                    new Date("2023-05-30"),
+                    new Date("2023-06-07"),
+                    new Date("2023-06-13"),
+                    new Date("2023-06-22"),
+                    new Date("2023-05-31"),
+                    new Date("2023-06-06"),
+                    new Date("2023-06-20"),
+                    new Date("2023-06-02"),
+                    new Date("2023-06-12"),
+                    new Date("2023-06-10"),
+                    new Date("2023-06-24"),
+                    new Date("2023-06-28"),
+                    new Date("2023-06-21"),
+                    new Date("2023-06-27"),
+                    new Date("2023-06-11"),
+                    new Date("2023-06-26"),
+                    new Date("2023-06-29"),
+                    new Date("2023-06-19"),
+                    new Date("2023-06-23"),
+                ]));
+
                 navigate('/home');
             }).catch((error) => {
                 // const errorCode = error.code;
@@ -179,6 +211,37 @@ export default function Login() {
                     friendDup: true,
                     friendNup: true,
                 }));
+
+                // 유저 B 캘린더 더미 값
+                dispatch(bDateUpdate([
+                    new Date("2023-06-20"),
+                    new Date("2023-05-28"),
+                    new Date("2023-06-04"),
+                    new Date("2023-06-16"),
+                    new Date("2023-05-29"),
+                    new Date("2023-06-05"),
+                    new Date("2023-06-14"),
+                    new Date("2023-05-30"),
+                    new Date("2023-06-07"),
+                    new Date("2023-06-13"),
+                    new Date("2023-06-22"),
+                    new Date("2023-05-31"),
+                    new Date("2023-06-06"),
+                    new Date("2023-06-20"),
+                    new Date("2023-06-02"),
+                    new Date("2023-06-12"),
+                    new Date("2023-06-10"),
+                    new Date("2023-06-24"),
+                    new Date("2023-06-28"),
+                    new Date("2023-06-21"),
+                    new Date("2023-06-27"),
+                    new Date("2023-06-11"),
+                    new Date("2023-06-26"),
+                    new Date("2023-06-29"),
+                    new Date("2023-06-19"),
+                    new Date("2023-06-23"),
+                ]));
+
                 navigate('/home');
             })
             .catch((error) => {
@@ -231,12 +294,42 @@ export default function Login() {
                     friendDup: true,
                     friendNup: true,
                 }));
+
+                // 유저 B 캘린더 더미 값
+                dispatch(bDateUpdate([
+                    new Date("2023-06-20"),
+                    new Date("2023-05-28"),
+                    new Date("2023-06-04"),
+                    new Date("2023-06-16"),
+                    new Date("2023-05-29"),
+                    new Date("2023-06-05"),
+                    new Date("2023-06-14"),
+                    new Date("2023-05-30"),
+                    new Date("2023-06-07"),
+                    new Date("2023-06-13"),
+                    new Date("2023-06-22"),
+                    new Date("2023-05-31"),
+                    new Date("2023-06-06"),
+                    new Date("2023-06-20"),
+                    new Date("2023-06-02"),
+                    new Date("2023-06-12"),
+                    new Date("2023-06-10"),
+                    new Date("2023-06-24"),
+                    new Date("2023-06-28"),
+                    new Date("2023-06-21"),
+                    new Date("2023-06-27"),
+                    new Date("2023-06-11"),
+                    new Date("2023-06-26"),
+                    new Date("2023-06-29"),
+                    new Date("2023-06-19"),
+                    new Date("2023-06-23"),
+                ]));
+
                 navigate('/home');
             })
             .catch((error) => {
-                const errorCode = error.code;
-                const errorMessage = error.message;
-                console.log('로그인 실패')
+                // const errorCode = error.code;
+                // const errorMessage = error.message;
                 alert('아이디나 비밀번호가 잘못되었습니다!');
             });
     }

--- a/src/slice/calendarSlice.js
+++ b/src/slice/calendarSlice.js
@@ -7,6 +7,8 @@ export const calendarSlice = createSlice({
     nowdate: new Date(),
     //다음달 달력 값
     nextdate: new Date(now.setMonth(now.getMonth()+1)),
+    //B캘린더 가짜 일정 값
+    bDate: [],
   },
   reducers: {
     //2달 다음으로 넘기는 reducer : 달력 2개인 구간
@@ -45,8 +47,18 @@ export const calendarSlice = createSlice({
         state.nextdate.setMonth(state.nextdate.getMonth() - 2)
       );
     },
+    // B캘린더 가짜 약속 추가 + 업데이트
+    bDateUpdate: (state, action) => {
+      state.bDate = action.payload;
+      sessionStorage.setItem('bDate', JSON.stringify(action.payload));
+    },
+    // B캘린더 가짜 약속 삭제
+    bDateDelete: (state, action) => {
+      state.bDate.slice(action.payload, 1);
+      sessionStorage.setItem('bDate', JSON.stringify(state.bDate));
+    }
   },
 });
-export const { next2month, prev2month, next1month, prev1month } =
+export const { next2month, prev2month, next1month, prev1month, bDateUpdate, bDateDelete } =
   calendarSlice.actions;
 export default calendarSlice.reducer;

--- a/src/slice/friendSlice.js
+++ b/src/slice/friendSlice.js
@@ -6,7 +6,7 @@ export const friendSlice = createSlice({
         friend : []
     },
     reducers : {
-        // 친구 리스트 불러오기
+        // 친구 리스트 불러오기 + 업데이트
         getfriendList : (state, action) => {
             state.friend = action.payload;
             sessionStorage.setItem('friend', JSON.stringify(action.payload));
@@ -21,10 +21,6 @@ export const friendSlice = createSlice({
             state.friend.splice(action.payload, 1);
             sessionStorage.setItem('friend', JSON.stringify(state.friend));
         },
-        // no 세션스토로지로 저장하기?
-        noSessionfriendList : (state, action) => {
-            state.friend = action.payload;
-        }
     }
 })
 

--- a/src/slice/markSlice.js
+++ b/src/slice/markSlice.js
@@ -6,16 +6,6 @@ export const markSlice = createSlice({
         userMark : []
     },
     reducers : {
-        // 관심 그룹 추가
-        adduserMark: (state, action) => {
-            state.userMark.push(action.payload);
-            sessionStorage.setItem('userMark', JSON.stringify(state.userMark));
-        },
-        // 관심 그룹 삭제
-        deleteuserMark: (state, action) => {
-            state.userMark.splice(action.payload, 1);
-            sessionStorage.setItem('userMark', JSON.stringify(state.userMark));
-        },
         // 관심 그룹 갱신
         updateMark : (state, action) => {
             state.userMark = action.payload;

--- a/src/slice/userSlice.js
+++ b/src/slice/userSlice.js
@@ -28,6 +28,7 @@ export const userSlice = createSlice({
             sessionStorage.removeItem('appointment');
             sessionStorage.removeItem('userMark');
             sessionStorage.removeItem('listArray');
+            sessionStorage.removeItem('bDate');
         },
         //true이면 A캘린더가 볼 수 있도록 bool 값을 true로
         setTrue:(state)=>{


### PR DESCRIPTION
마이페이지에서 B캘린더 날짜 추가/삭제 하면 홈B캘린더에도 해당 날짜 적용됨
리덕스, 세션스토로지에 데이터 저장함 (파이어스토어X)

세션값에 날짜 데이터가 해외기준으로 들어가서 표기가 다른데 작동에는 문제 없음.